### PR TITLE
Replace with functional commands

### DIFF
--- a/docs/day-1-exercises.md
+++ b/docs/day-1-exercises.md
@@ -18,7 +18,7 @@ added!
 
 - [ ] Run `./mvnw clean compile`
 
-- [ ] Run `./mvnw test -DTest="D1E1Test"` to check it's right, then commit and
+- [ ] Run `./mvnw test -Dtest=D1E1Test` to check it's right, then commit and
       push
 
 ## Exercise 2: Creating a CLI
@@ -54,7 +54,7 @@ specifications:
 > ./mvnw exec:java -Phelloworld
 > ```
 
-- [ ] Run `./mvnw test -DTest="D1E2Test"` to check it's right, then commit and
+- [ ] Run `./mvnw test -Dtest=D1E2Test` to check it's right, then commit and
       push
 
 ## Exercise 3: Adding params
@@ -66,7 +66,7 @@ specifications:
 - [ ] Set `defaultValue = "World"` in the parameter to ensure that Exercise 2
       doesn't break!
 
-- [ ] Run `./mvnw test -DTest="D1E3Test"` to check it's right, then commit and
+- [ ] Run `./mvnw test -Dtest=D1E3Test` to check it's right, then commit and
       push
 
 > [!TIP]
@@ -91,7 +91,7 @@ attach it to the `HelloWorld` app!
 - [ ] Add the `ColorCommand` subcommand to the `HelloWorld` app by including it
       in the `subcommands` argument.
 
-- [ ] Run `./mvnw test -DTest="D1E4Test"` to check it's right, then commit and
+- [ ] Run `./mvnw test -Dtest=D1E4Test` to check it's right, then commit and
       push
 
 > [!NOTE]


### PR DESCRIPTION
These command line options are case-sensitive, so `DTest` is just ignored and all tests are run. (`Dtest` is the correct command line option.) The test specification also doesn't require quotes, as far as I can tell!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Standardised test command instructions in the `day-1-exercises.md` document for consistency across multiple exercises.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->